### PR TITLE
fix: commitlint

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,0 +1,1 @@
+export default { extends: ['@commitlint/config-conventional'] };


### PR DESCRIPTION
This pull request includes a small change to the `commitlint.config.ts` file. The change sets the default export to extend the conventional commit lint configuration.

* [`commitlint.config.ts`](diffhunk://#diff-d683e2c690c3cd50f9088ac0671cad1de831e7520400f67339bbd8729e57818fR1): Exported default configuration to extend `@commitlint/config-conventional`.